### PR TITLE
fix: datadir

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,7 +29,7 @@ if (Environment.isProduction() || Environment.isAlpha()) {
 } else if (Environment.isDevelopment()) {
     envConfig = new DevelopmentEnvConfig();
 } else if (Environment.isTest()) {
-    envConfig = new TestEnvConfig(process.env.MP_DATA_FOLDER || './data', process.env.MP_DOTENV_FILE || '.env.test');
+    envConfig = new TestEnvConfig(process.env.MP_DATA_FOLDER || './data/tests', process.env.MP_DOTENV_FILE || '.env.test');
 } else if (Environment.isBlackBoxTest()) {
     envConfig = new TestEnvConfig(process.env.MP_DATA_FOLDER || './data', process.env.MP_DOTENV_FILE || '.env.blackbox');
 } else {

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -79,8 +79,8 @@ export class App {
         this.log.info('Configuring app...');
 
         // Initialize the data directory
+        await DataDir.initialize();
         if (process.env.INIT) {
-            await DataDir.initialize();
             await DataDir.createDefaultEnvFile();
         }
 

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -91,7 +91,7 @@ export class DataDir {
     }
 
     public static async initialize(): Promise<boolean> {
-        console.log("DataDir: initializing folder structure..");
+        console.log('DataDir: initializing folder structure..');
         const datadir = this.getDataDirPath();
         const database = this.getDatabasePath();
         const uploads = this.getUploadsPath();
@@ -118,7 +118,7 @@ export class DataDir {
             fs.mkdirSync(uploads);
         }
 
-        console.log("DataDir: should've created all folder, checking..");
+        console.log('DataDir: shouldve created all folder, checking..');
         // do a final check, doesn't hurt.
         return this.check();
     }

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -121,7 +121,7 @@ export class DataDir {
         }
 
         console.log('DataDir: shouldve created all folder, checking..');
-        
+
         // do a final check, doesn't hurt.
         const ok = this.check();
         console.log('DataDir: is initialized: ', ok);

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -121,8 +121,11 @@ export class DataDir {
         }
 
         console.log('DataDir: shouldve created all folder, checking..');
+        
         // do a final check, doesn't hurt.
-        return this.check();
+        const ok = this.check();
+        console.log('DataDir: is initialized: ', ok);
+        return ok;
     }
 
     public static check(): boolean {

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -84,7 +84,7 @@ export class DataDir {
             // console.log('found:', dir);
             return true;
         } catch (err) {
-            if(!expectFailure) {
+            if (!expectFailure) {
                 console.error('DataDir: Could not find path:', dir);
                 console.error(err);
             }

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -84,12 +84,14 @@ export class DataDir {
             // console.log('found:', dir);
             return true;
         } catch (err) {
-            console.error('Could not find path:', dir);
+            console.error('DataDir: Could not find path:', dir);
+            console.error(err);
         }
         return false;
     }
 
     public static async initialize(): Promise<boolean> {
+        console.log("DataDir: initializing folder structure..");
         const datadir = this.getDataDirPath();
         const database = this.getDatabasePath();
         const uploads = this.getUploadsPath();
@@ -116,6 +118,7 @@ export class DataDir {
             fs.mkdirSync(uploads);
         }
 
+        console.log("DataDir: should've created all folder, checking..");
         // do a final check, doesn't hurt.
         return this.check();
     }
@@ -155,10 +158,10 @@ export class DataDir {
                 dir = path.dirname(dir);
                 const try2 = path.join(dir, '.env');
                 if (this.checkIfExists(try2)) {
-                    console.log('found the local .env', try2);
+                    console.log('DataDir: found the local .env', try2);
                     dotenv = try2;
                 } else {
-                    console.error('src .env not found');
+                    console.error('DataDir: src .env not found');
                     reject('src .env not found');
                 }
             }

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -78,14 +78,16 @@ export class DataDir {
         return path.join(this.getDataDirPath(), 'marketplace.log');
     }
 
-    public static checkIfExists(dir: string): boolean {
+    public static checkIfExists(dir: string, expectFailure?: boolean): boolean {
         try {
             fs.accessSync(dir, (fs.constants || fs).R_OK);
             // console.log('found:', dir);
             return true;
         } catch (err) {
-            console.error('DataDir: Could not find path:', dir);
-            console.error(err);
+            if(!expectFailure) {
+                console.error('DataDir: Could not find path:', dir);
+                console.error(err);
+            }
         }
         return false;
     }
@@ -101,20 +103,20 @@ export class DataDir {
         // TODO: might not be the best check
         if (datadir.endsWith('testnet') || datadir.endsWith('tesnet/')) {
             const dir = path.dirname(datadir); // pop the 'testnet' folder name
-            if (!this.checkIfExists(dir)) {
+            if (!this.checkIfExists(dir, true)) {
                 fs.mkdirSync(dir);
             }
         }
 
-        if (!this.checkIfExists(datadir)) {
+        if (!this.checkIfExists(datadir, true)) {
             fs.mkdirSync(datadir);
         }
 
-        if (!this.checkIfExists(database)) {
+        if (!this.checkIfExists(database, true)) {
             fs.mkdirSync(database);
         }
 
-        if (!this.checkIfExists(uploads)) {
+        if (!this.checkIfExists(uploads, true)) {
             fs.mkdirSync(uploads);
         }
 

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -33,12 +33,6 @@ export class DataDir {
             return this.datadir;
         }
 
-        // in dev/test environment
-        if (!Environment.isAlpha() && !Environment.isProduction()) {
-            this.datadir = './data/';
-            return this.datadir;
-        }
-
         const homeDir: string = os.homedir ? os.homedir() : process.env['HOME'];
 
         let dir = '';
@@ -77,7 +71,7 @@ export class DataDir {
     }
 
     public static getDatabaseFile(): string {
-        return path.join(this.getDatabasePath(), !Environment.isTest() ? 'marketplace.db' : 'marketplace-test.db');
+        return path.join(this.getDatabasePath(), 'marketplace.db');
     }
 
     public static getLogFile(): string {

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -21,7 +21,7 @@ export class DataDir {
 
     public static set(dir?: string): void {
         if (dir) {
-            this.datadir = dir;
+            this.datadir = path.resolve(dir);
         }
     }
 

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -80,7 +80,7 @@ export class DataDir {
 
     public static checkIfExists(dir: string): boolean {
         try {
-            fs.accessSync(dir, fs.constants.R_OK);
+            fs.accessSync(dir, (fs.constants || fs).R_OK);
             // console.log('found:', dir);
             return true;
         } catch (err) {


### PR DESCRIPTION
Automatically initialize the data directory layout when bootstrapping.
Add separate root directory for 'tests'.
Fix issue with Node >=6 <6.3
Add extra logging

Default structure:
```
DATADIR
   uploads
   database
   (.env file)
```

The current structure (local)
```
data
   uploads
   database
   tests
      uploads
      database
```

Perhaps we should change this to:
```
data
   mainnet
      uploads
      database
   testnet
      uploads
      database
   tests
      uploads
      database
```