### PR TITLE
add APPDATA env variable

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -11,6 +11,7 @@ let proc: ChildProcess;
 exports.start = () => {
     const p = path.join(__dirname, 'app.js');
     const environment = {
+        APPDATA: process.env.APPDATA,
         NODE_ENV: 'alpha',
         TESTNET: true,
         INIT: true,


### PR DESCRIPTION
The intitial env seems to be completly overwritten, so we hack this appdata in from the original process. Weird.