### PR TITLE
When generating votes, create a proposalResult entry if it does not exist.

### DIFF
--- a/src/api/services/ProposalService.ts
+++ b/src/api/services/ProposalService.ts
@@ -209,8 +209,13 @@ export class ProposalService {
         this.log.debug('recalculateProposalResult(), proposal.id: ', proposal.id);
 
         // fetch the latest ProposalResult to get the latest id
+        let proposalResult: resources.ProposalResult;
         let proposalResultModel = await this.proposalResultService.findOneByProposalHash(proposal.hash);
-        let proposalResult: resources.ProposalResult = proposalResultModel.toJSON();
+        if (!proposalResultModel) {
+            proposalResult = await this.createProposalResult(proposal);
+        } else {
+            proposalResult = proposalResultModel.toJSON();
+        }
 
         // TODO: rather than update, we should create new ProposalResult
         // first update the calculatedAt in ProposalResult


### PR DESCRIPTION
Helps to prevent method call on undefined object errors (if proposalResultModel failed to be populated due to a proposalResult not previously existing).