### PR TITLE
Removes default env for DB_CONNECTION

### DIFF
--- a/src/config/env/EnvConfig.ts
+++ b/src/config/env/EnvConfig.ts
@@ -51,7 +51,6 @@ export class EnvConfig {
         MONITOR_ENABLED: true,
         MONITOR_ROUTE: '/status',
         DB_CLIENT: 'sqlite3',
-        DB_CONNECTION: './data/database/marketplace-test.db',
         DB_POOL_MIN: 2,
         DB_POOL_MAX: 10,
         DB_MIGRATION_TABLE: 'version',


### PR DESCRIPTION
Running the built version as an include into another project, the DB_CONNECTION variable configures the marketplace to look for the DB in a path relative to the current directory, instead of its default (eg: ~/.particl-market/testnet/database/ on linux). This causes an exception to be thrown when the DB is not found, preventing the marketplace from running.

Removing the default DB_CONNECTION env config allows for the marketplace to be found in the correct directory.

