### PR TITLE
Remove the sum for small enough UTXOS when finding utxos for transactions

### DIFF
--- a/src/api/services/BidActionService.ts
+++ b/src/api/services/BidActionService.ts
@@ -233,7 +233,7 @@ export class BidActionService {
         let selectedOutputsSum = 0;
         let selectedOutputsChangeAmount = 0;
 
-        const utxoLessThanReqestedAmount: number[] = [];
+        // const utxoLessThanReqestedAmount: number[] = [];
         let utxoIdxs: number[] = [];
 
         let exactMatchIdx = -1;
@@ -250,9 +250,9 @@ export class BidActionService {
                     if ( (exactMatchIdx === -1) && ( this.correctNumberDecimals(output.amount - adjustedRequiredAmount) === 0) ) {
                         // Found a utxo with amount that is an exact match for the requested amount.
                         exactMatchIdx = outIdx;
-                    } else if (output.amount < adjustedRequiredAmount) {
-                        // utxo is less than the amount requested, so may be summable with others to get to the exact value (or within a close threshold).
-                        utxoLessThanReqestedAmount.push(outIdx);
+                    // } else if (output.amount < adjustedRequiredAmount) {
+                    //     // utxo is less than the amount requested, so may be summable with others to get to the exact value (or within a close threshold).
+                    //     utxoLessThanReqestedAmount.push(outIdx);
                     }
 
                     // Get the max utxo amount in case an output needs to be split

--- a/src/api/services/BidActionService.ts
+++ b/src/api/services/BidActionService.ts
@@ -277,9 +277,10 @@ export class BidActionService {
         // Step 1: Check whether an exact match was found.
         if (exactMatchIdx === -1) {
             // No exact match found, so...
-            //  ... Step 2: Sum utxos to find a summed group that matches exactly or is greater than the required amount by no more than 1%.
+            //  ... Step 2: Ignore this step since it literally takes forever to complete
+            //  Sum utxos to find a summed group that matches exactly or is greater than the required amount by no more than 1%.
             // NB!! Only do this if number of utxos <= 12 (which is 4096 combinations to test for - any more and performance drastically suffers)
-            const requiredTestCases = utxoLessThanReqestedAmount.length <= 12 ? 0 : Math.pow(2, utxoLessThanReqestedAmount.length);
+            /* const requiredTestCases = utxoLessThanReqestedAmount.length <= 12 ? 0 : Math.pow(2, utxoLessThanReqestedAmount.length);
             for (let ii = 0; ii < requiredTestCases; ii++) {
                 const potentialIdxs: number[] = utxoLessThanReqestedAmount.filter((num: number, index: number) => ii & (1 << index) );
                 const summed: number = this.correctNumberDecimals(
@@ -298,7 +299,7 @@ export class BidActionService {
                     }
                 }
             }
-
+            */
             // ... Step 3: If no summed values found, attempt to split a large enough output.
             if (utxoIdxs.length === 0 && maxOutputIdx !== -1 && unspentOutputs[maxOutputIdx].amount > adjustedRequiredAmount) {
                 const newAddress = await this.coreRpcService.getNewAddress([], false);


### PR DESCRIPTION
Seems that this still takes a significant amount of time to complete, even with the check for fewer utxos. So removing the bottleneck processing for now.