### PR TITLE
Corrects issues with template images

### DIFF
--- a/src/api/services/ListingItemActionService.ts
+++ b/src/api/services/ListingItemActionService.ts
@@ -76,16 +76,10 @@ export class ListingItemActionService {
 
         // fetch the listingItemTemplate
         const itemTemplateModel = await this.listingItemTemplateService.findOne(data.listingItemTemplateId, true);
-        let itemTemplate = itemTemplateModel.toJSON();
+        const itemTemplate = itemTemplateModel.toJSON();
 
         // TODO: should validate that the template has the required info
         // TODO: recalculate the template.hash in case the related data has changed
-
-        const listingMessageSizeData: MessageSize = await this.listingItemTemplateService.calculateMarketplaceMessageSize(itemTemplate);
-        if (!listingMessageSizeData.fits) {
-            itemTemplate = await this.listingItemTemplateService.createResizedTemplateImages(itemTemplate);
-            this.log.debug('images resized');
-        }
 
         // this.log.debug('post template: ', JSON.stringify(itemTemplate, null, 2));
         // get the templates profile address

--- a/src/core/helpers/ImageProcessing.ts
+++ b/src/core/helpers/ImageProcessing.ts
@@ -815,8 +815,7 @@ export class ImageProcessing {
     public static async resizeImageToFit(imageRaw: string, maxWidth: number, maxHeight: number): Promise<string> {
         const dataBuffer = Buffer.from(imageRaw, 'base64');
         const imageBuffer: any = await Jimp.read(dataBuffer);
-        // resize only if target sizes > 0, else return original
-        if (maxWidth > 0 && maxHeight > 0 && (dataBuffer.width > maxWidth && dataBuffer.height > maxHeight)) {
+        if (maxWidth > 0 && maxHeight > 0 && ( (imageBuffer.bitmap.width > maxWidth) || (imageBuffer.bitmap.height > maxHeight))) {
             imageBuffer.scaleToFit(maxWidth, maxHeight);
             const mimeType = imageBuffer.getMIME() !== 'image/jpeg' ? Jimp.MIME_JPEG : 'image/jpeg';
             const resizedImage = await imageBuffer.getBuffer(mimeType, (err, buffer) => {
@@ -852,18 +851,16 @@ export class ImageProcessing {
 
     public static async downgradeQuality(imageRaw: string, quality: number): Promise<string> {
       const dataBuffer = Buffer.from(imageRaw, 'base64');
-      const imageBuffer: any = await Jimp.read(dataBuffer);
-      imageBuffer.quality(quality);
+      let imageBuffer: any = await Jimp.read(dataBuffer);
+      imageBuffer = imageBuffer.quality(quality);
       if (imageBuffer.getMIME() !== 'image/jpeg') {
-        imageRaw = await imageBuffer.getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
+        return await imageBuffer.getBuffer(Jimp.MIME_JPEG, (err, buffer) => {
           return buffer.toString('base64');
         });
-        return imageRaw;
       } else {
-        imageRaw = await imageBuffer.getBuffer('image/jpeg', (err, buffer) => {
+        return await imageBuffer.getBuffer('image/jpeg', (err, buffer) => {
           return buffer.toString('base64');
         });
-        return imageRaw;
       }
 
     }


### PR DESCRIPTION
The purpose for this change is to try and decrease the image quality of templates to try and lower the listing fee (reducing the byte size of included images reduces the byte size of the resulting smsgmessage, lowering listing cost). 

While the increased cost as of the latest version is likely due to a bug in the image resizing function call (fixed in this change as well), the idea is to fix the template image quality at a lowest acceptable minimum for the RESIZED image. Rather than setting it to its lowest and then attempting to increase quality (which increase byte size of the images up to its original quality, which increase listing cost).

Below are the changes: 

* Fixes a bug in the image resizing condition (invalid image width/height values used), causing the original image dimensions to always be used instead of resizing the image appropriately.

* Removes the image quality adjustments when processing a template if the template is larger than the smsgmessage - the validation in ListingItemTemplatePostCommand should prevent this from executing.

* Image quality is now fixed at the lowest compression value, instead of trying to find a higher quality. Along with decreaasing the RESIZED image dimensions, this attempts to lower the resulting smsgmessage size (decreasing listing costs). Also, because a fixed quality compression value is used, we avoid conflicts with other templates using the same image and adjusting the image quality affecting the remaining templates using the same image. The latter reason is also why the resizing only occurs if a resized image does not exist (speeds up image processing as well)