### PR TITLE
Changes the smsg decoding for particld-v0.18.x

### DIFF
--- a/src/api/services/SmsgService.ts
+++ b/src/api/services/SmsgService.ts
@@ -169,7 +169,7 @@ export class SmsgService {
         const response = await this.coreRpcService.call('smsg', [msgId, {
                 delete: remove,
                 setread: setRead,
-                encoding: 'ascii'
+                encoding: 'text'
             }
         ]);
         // this.log.debug('smsg, response: ' + JSON.stringify(response, null, 2));


### PR DESCRIPTION
The hard-fork on testnet on February 16 2019 requires that particld v0.18.x be used.
Particl-desktop has updated to this version version for testnet already.

However, the encoding options available for retrieving an smsgmessage from the core has been updated as follows:

 ```
$ ./particl-cli -testnet help smsg
smsg "msgid" ( options )

View smsg by msgid.

Arguments:
1. msgid                     (string, required) Id of the message to view.
2. options                   (json object, optional)
     {
       "delete": bool,       (boolean, optional, default=false) Delete msg if true.
       "setread": bool,      (boolean, optional, default=false) Set read status to value.
       "encoding": "str",    (string, optional, default=text) Display message data in encoding, values: "text", "hex", "none".
     }

```

Note that "encoding" no longer includes 'ascii' as an option - seems to have been replaced by text.
Using eh encoding option 'ascii' currently with the 0.18.0.1 daemon, parsing of JSON messages is failing resulting in no listings or proposals being displayed (with the smsgmessage being deleted afterwards).

Changing this to the 'text' option as proposed by the daemon resolves the parsing error.