### PR TITLE
Fixes the dropping of hdmasterkeyid in getwalletinfo rpc of v0.18.0.3 particld

### DIFF
--- a/src/api/services/CoreRpcService.ts
+++ b/src/api/services/CoreRpcService.ts
@@ -85,7 +85,7 @@ export class CoreRpcService {
 
     public async hasWallet(): Promise<boolean> {
         return await this.getWalletInfo()
-            .then(response => (response && response.hdmasterkeyid))
+            .then(response => (response && response.hdseedid))
             .catch(error => {
                 return false;
             });


### PR DESCRIPTION
"hdseedid" can be used for the same purpose and has been present in previous core versions as well, so should not break compatibility with previous versions used.