### PR TITLE
Cleanup TESTNET environment variable

### DIFF
--- a/.env.blackbox.example
+++ b/.env.blackbox.example
@@ -9,7 +9,6 @@ APP_HOST=http://localhost
 APP_URL_PREFIX=/api
 APP_PORT=3100
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=localhost

--- a/.env.ci.app1
+++ b/.env.ci.app1
@@ -9,7 +9,6 @@ APP_HOST=http://circle.particl.xyz
 APP_URL_PREFIX=/api
 APP_PORT=3000
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=circle.particl.xyz

--- a/.env.ci.blackbox
+++ b/.env.ci.blackbox
@@ -9,7 +9,6 @@ APP_HOST=http://circle.particl.xyz
 APP_URL_PREFIX=/api
 APP_PORT=3100
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=circle.particl.xyz

--- a/.env.ci.test
+++ b/.env.ci.test
@@ -9,7 +9,6 @@ APP_HOST=http://circle.particl.xyz
 APP_URL_PREFIX=/api
 APP_PORT=3100
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=circle.particl.xyz

--- a/.env.dist
+++ b/.env.dist
@@ -10,7 +10,6 @@ APP_URL_PREFIX=/api
 APP_PORT=3000
 
 # Comment out the RPCUSER and RPCPASSWORD in case you want to use the cookie instead.
-TESTNET=true
 #RPCUSER=test
 #RPCPASSWORD=test
 RPCHOSTNAME=localhost

--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -9,7 +9,6 @@ APP_HOST=http://localhost
 APP_URL_PREFIX=/api
 APP_PORT=3100
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=localhost

--- a/.env.test.example
+++ b/.env.test.example
@@ -9,7 +9,6 @@ APP_HOST=http://localhost
 APP_URL_PREFIX=/api
 APP_PORT=3000
 
-TESTNET=true
 RPCUSER=test
 RPCPASSWORD=test
 RPCHOSTNAME=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     environment:
       - NODE_ENV=development
       - APP_PORT=3100
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld1
@@ -50,7 +49,6 @@ services:
     environment:
       - NODE_ENV=development
       - APP_PORT=3200
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld2

--- a/kontena-circle.yml
+++ b/kontena-circle.yml
@@ -70,7 +70,6 @@ services:
       - APP_HOST=http://circle.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3000
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld1
@@ -107,7 +106,6 @@ services:
       - APP_HOST=http://localhost
       - APP_URL_PREFIX=/api
       - APP_PORT=3000
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld2

--- a/kontena-develop.yml
+++ b/kontena-develop.yml
@@ -60,7 +60,6 @@ services:
       - APP_HOST=http://dev1.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld1
@@ -110,7 +109,6 @@ services:
       - APP_HOST=http://dev2.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld2

--- a/kontena-feature.yml
+++ b/kontena-feature.yml
@@ -60,7 +60,6 @@ services:
       - APP_HOST=http://feature1.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld1
@@ -110,7 +109,6 @@ services:
       - APP_HOST=http://feature2.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld2

--- a/kontena-master.yml
+++ b/kontena-master.yml
@@ -60,7 +60,6 @@ services:
       - APP_HOST=http://master1.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld1
@@ -108,7 +107,6 @@ services:
       - APP_HOST=http://master2.particl.xyz
       - APP_URL_PREFIX=/api
       - APP_PORT=3333
-      - TESTNET=true
       - RPCUSER=test
       - RPCPASSWORD=test
       - RPCHOSTNAME=particld2

--- a/src/api/services/CoreRpcService.ts
+++ b/src/api/services/CoreRpcService.ts
@@ -573,7 +573,6 @@ export class CoreRpcService {
     private getUrl(): string {
         // this.log.debug('Environment.isTestnet():', Environment.isTestnet());
         // this.log.debug('Environment.isAlpha():', Environment.isAlpha());
-        // this.log.debug('process.env.TESTNET:', process.env.TESTNET);
 
         const host = (process.env.RPCHOSTNAME ? process.env.RPCHOSTNAME : this.DEFAULT_HOSTNAME);
         const port = process.env.RPC_PORT ?

--- a/src/config/env/EnvConfig.ts
+++ b/src/config/env/EnvConfig.ts
@@ -23,7 +23,6 @@ export class EnvConfig {
         RPCHOSTNAME: 'localhost',
         MAINNET_PORT: 51738,
         TESTNET_PORT: 51935,
-        TESTNET: true,
         REGTEST_PORT: 19792,
         REGTEST: false,
         INIT: true,

--- a/src/core/helpers/Environment.ts
+++ b/src/core/helpers/Environment.ts
@@ -66,7 +66,7 @@ export class Environment {
     }
 
     public static isTestnet(): boolean {
-        return this.isTruthy(process.env.TESTNET) || this.isAlpha();
+        return !this.isProduction();
     }
 
     public static isRegtest(): boolean {

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,6 @@ exports.start = (envArgs: any) => {
     const environment = {
         APPDATA: process.env.APPDATA,
         NODE_ENV: 'alpha',
-        TESTNET: true,
         INIT: true,
         MIGRATE: true,
         ELECTRON_RUN_AS_NODE: true


### PR DESCRIPTION
Removes the TESTNET environment variable, preferring the determination of testnet/mainnet chain to be determined from the NODE_ENV venvironment variable.

The change means that all values for NODE_ENV will default to testnet configuration, except for NODE_ENV="PRODUCTION" which makes use of mainnet configuration.