### PR TITLE
PBD-264 - Add ability to filter flagged (for removal) items on listing view

### DIFF
--- a/src/api/models/ListingItem.ts
+++ b/src/api/models/ListingItem.ts
@@ -192,7 +192,11 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
                 }
 
                 if (options.flagged) {
+                    // ListingItems having FlaggedItem and ignore whether or not FlaggedItem has the removed flag.
                     qb.innerJoin('flagged_items', 'listing_items.id', 'flagged_items.listing_item_id');
+                } else {
+                    // Show all listingitems, but dont include the ones having ListingItem.FlaggedItem.removed
+                    qb.where('listing_items.removed', '=', false);
                 }
 
                 if (options.withBids && !joinedBids) { // Don't want to join twice or we'll get errors.
@@ -226,6 +230,9 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
 
     public get Hash(): string { return this.get('hash'); }
     public set Hash(value: string) { this.set('hash', value); }
+
+    public get Removed(): string { return this.get('removed'); }
+    public set Removed(value: string) { this.set('removed', value); }
 
     public get Seller(): string { return this.get('seller'); }
     public set Seller(value: string) { this.set('seller', value); }

--- a/src/api/requests/ListingItemUpdateRequest.ts
+++ b/src/api/requests/ListingItemUpdateRequest.ts
@@ -9,6 +9,7 @@ import { RequestBody } from '../../core/api/RequestBody';
 export class ListingItemUpdateRequest extends RequestBody {
 
     public hash: string;
+    public removed: boolean;
 
     @IsNotEmpty()
     public seller: string;

--- a/src/api/services/ListingItemActionService.ts
+++ b/src/api/services/ListingItemActionService.ts
@@ -137,6 +137,16 @@ export class ListingItemActionService {
         const listingItemMessage: ListingItemMessage = marketplaceMessage.item as ListingItemMessage;
 
         if (marketplaceMessage.market && marketplaceMessage.item) {
+            try {
+                const tmpListingItem = await this.listingItemService.findOneByHash(listingItemMessage.hash);
+                // If no error was thrown and a value was returned then we have a listing item with this hash already
+                if (tmpListingItem) {
+                    // Ignore listings with duplicated hashes.
+                    return SmsgMessageStatus.IGNORED;
+                }
+            } catch (ex) {
+                // Do nothing
+            }
 
             // get market
             const marketModel = await this.marketService.findByAddress(marketplaceMessage.market);

--- a/src/api/services/ListingItemService.ts
+++ b/src/api/services/ListingItemService.ts
@@ -213,6 +213,7 @@ export class ListingItemService {
         listingItem.PostedAt = body.postedAt;
         listingItem.ExpiredAt = body.expiredAt;
         listingItem.ReceivedAt = body.receivedAt;
+        listingItem.Removed = body.removed;
 
         // and update the ListingItem record
         const updatedListingItem = await this.listingItemRepo.update(id, listingItem.toJSON());
@@ -376,6 +377,21 @@ export class ListingItemService {
            }
        }
     }
+
+    /**
+     * Flag listing as removed
+     *
+     * @returns {Promise<void>}
+     */
+    public async setRemovedFlag(itemHash: string, flag: boolean): Promise<void> {
+        const listingItemModel = await this.findOneByHash(itemHash);
+        if (!listingItemModel) {
+            this.log.error('Item listing does not exist. hash = ' + itemHash);
+            throw new NotFoundException('Item listing does not exist. hash = ' + itemHash);
+        }
+        const {id} = listingItemModel.toJSON();
+        await this.listingItemRepo.update(id, {removed: flag});
+     }
 
     /**
      * check if object is exist in a array

--- a/src/database/migrations/20170902223923_create_listing_items_table.ts
+++ b/src/database/migrations/20170902223923_create_listing_items_table.ts
@@ -22,6 +22,7 @@ exports.up = (db: Knex): Promise<any> => {
             table.foreign('listing_item_template_id').references('id')
                 .inTable('listing_item_templates').onDelete('cascade');
 
+            table.boolean('removed').notNullable().defaultTo(false);
             table.integer('expiry_time').unsigned();
             table.integer('received_at').notNullable();
             table.integer('posted_at').notNullable();

--- a/src/types/resources/listingItem.d.ts
+++ b/src/types/resources/listingItem.d.ts
@@ -9,6 +9,7 @@ declare module 'resources' {
         hash: string;
         seller: string;
         expiryTime: number;
+        removed: boolean;
 
         receivedAt: number;
         postedAt: number;


### PR DESCRIPTION
This PR works on the one from Cube (https://github.com/particl/particl-market/pull/384)

This also includes PBD-235, MP - ListingItemMessages having existing hash should be ignored

There is a particl-desktop PR that goes with this PR