### PR TITLE
Adds ability for custom cookie file lookup for daemon(core) auth.

### DIFF
--- a/src/api/services/CoreCookieService.ts
+++ b/src/api/services/CoreCookieService.ts
@@ -23,6 +23,7 @@ export class CoreCookieService {
 
     private DEFAULT_CORE_USER = 'test';
     private DEFAULT_CORE_PASSWORD = 'test';
+    private CORE_COOKIE_FILE = process.env.RPCCOOKIEFILE ? process.env.RPCCOOKIEFILE : '.cookie';
 
     private PATH_TO_COOKIE: string;
 
@@ -124,7 +125,7 @@ export class CoreCookieService {
         // just check if it exist so it logs an error just in case
         if (this.checkIfExists(dir)) {
             // return path to cookie
-            const cookiePath = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ), '.cookie');
+            const cookiePath = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ), this.CORE_COOKIE_FILE);
             this.PATH_TO_COOKIE = cookiePath;
             return cookiePath;
         }

--- a/src/config/env/EnvConfig.ts
+++ b/src/config/env/EnvConfig.ts
@@ -21,6 +21,7 @@ export class EnvConfig {
         APP_URL_PREFIX: '/api',
         APP_PORT: 3000,
         RPCHOSTNAME: 'localhost',
+        RPCCOOKIEFILE: '.cookie',
         MAINNET_PORT: 51738,
         TESTNET_PORT: 51935,
         REGTEST_PORT: 19792,


### PR DESCRIPTION
The cookie authentication file is a daemon specific file for generating random authentication details that a node can use to authenticate rpc connection details. According to the spec, the name of the file defaults to '.cookie', but an option does exist to provide an alternative name for this file.

This change simply allows for an alternative daemon authentication cookie filename to be specified, in case it exists.