### PR TITLE
Adds a fix for default market -> wallet creation.

### DIFF
--- a/src/api/commands/listingitemtemplate/ListingItemTemplatePostCommand.ts
+++ b/src/api/commands/listingitemtemplate/ListingItemTemplatePostCommand.ts
@@ -130,8 +130,10 @@ export class ListingItemTemplatePostCommand extends BaseCommand implements RpcCo
             throw new InvalidParamException('marketId', 'number');
         }
 
-        if (data.params[3] !== undefined && typeof data.params[3] !== 'boolean') {
-            throw new InvalidParamException('estimateFee', 'boolean');
+        if (data.params[3] !== undefined) {
+            if (typeof data.params[3] !== 'boolean') {
+                throw new InvalidParamException('estimateFee', 'boolean');
+            }
         } else {
             data.params[3] = false;
         }

--- a/src/api/commands/proposal/ProposalPostCommand.ts
+++ b/src/api/commands/proposal/ProposalPostCommand.ts
@@ -141,7 +141,7 @@ export class ProposalPostCommand extends BaseCommand implements RpcCommandInterf
 
         // get the default market.
         // TODO: Might want to let users specify this later.
-        const market: resources.Market = await this.marketService.getDefaultForProfile(data.params[0]).then(value => value.toJSON());
+        const market: resources.Market = await this.marketService.getDefaultForProfile(data.params[0].id).then(value => value.toJSON());
 
         data.params.unshift(market);
         return data;

--- a/src/api/listeners/ServerStartedListener.ts
+++ b/src/api/listeners/ServerStartedListener.ts
@@ -28,7 +28,6 @@ export class ServerStartedListener implements interfaces.Listener {
     public static Event = Symbol('ServerStartedListenerEvent');
 
     public log: LoggerType;
-    public isAppReady = false;
     public isStarted = false;
     private previousState = false;
 
@@ -62,10 +61,8 @@ export class ServerStartedListener implements interfaces.Listener {
      */
     public async act(payload: any): Promise<any> {
         this.log.info('Received event ServerStartedListenerEvent', payload);
-        this.isAppReady = true;
         await this.coreCookieService.scheduleCookieLoop();
         this.log.debug('this.coreCookieService.scheduleCookieLoop() DONE');
-        await this.configureRpcService();
         this.pollForConnection();
     }
 
@@ -119,7 +116,7 @@ export class ServerStartedListener implements interfaces.Listener {
                     }
 
                     // if there's no configuration for the market, set the isConnected back to false
-                    isConnected = hasMarketConfiguration ? true : false;
+                    isConnected = hasMarketConfiguration;
 
                     if (hasMarketConfiguration) {
 
@@ -185,15 +182,4 @@ export class ServerStartedListener implements interfaces.Listener {
         }
         return false;
     }
-
-    private async configureRpcService(): Promise<void> {
-        // if a wallet other than the default one is configured, then we need to set that one as the active one
-        await this.coreRpcService.listLoadedWallets()
-            .then(async wallets => {
-                this.log.debug('loaded wallets: ', wallets);
-                await this.coreRpcService.setActiveWallet(wallets[0]);
-            });
-        return;
-    }
-
 }

--- a/src/api/services/CoreRpcService.ts
+++ b/src/api/services/CoreRpcService.ts
@@ -18,6 +18,7 @@ import { CtRpc, RpcBlindSendToOutput } from 'omp-lib/dist/abstract/rpc';
 import { BlockchainInfo } from './CoreRpcService';
 import { BlindPrevout, CryptoAddress, CryptoAddressType, OutputType, Prevout } from 'omp-lib/dist/interfaces/crypto';
 import { fromSatoshis } from 'omp-lib/dist/util';
+import { SettingValue } from '../enums/SettingValue';
 
 declare function escape(s: string): string;
 declare function unescape(s: string): string;
@@ -90,6 +91,7 @@ export class CoreRpcService extends CtRpc {
     ) {
         super();
         this.log = new Logger(__filename);
+        this.activeWallet = process.env[SettingValue.DEFAULT_WALLET.toString()] ? process.env[SettingValue.DEFAULT_WALLET.toString()] : this.activeWallet;
     }
 
     public async isConnected(): Promise<boolean> {
@@ -109,6 +111,10 @@ export class CoreRpcService extends CtRpc {
             .catch(error => {
                 return false;
             });
+    }
+
+    public get currentWallet(): string {
+        return this.activeWallet;
     }
 
     public async setActiveWallet(wallet: string): Promise<void> {

--- a/src/api/services/DefaultMarketService.ts
+++ b/src/api/services/DefaultMarketService.ts
@@ -60,13 +60,26 @@ export class DefaultMarketService {
             throw new MessageException('Default Market settings not found!');
         }
 
-        // the initial default marketplace should use a wallet called market.dat
-        const defaultMarketWallet: resources.Wallet = await this.walletService.findOneByName('market.dat')
+        // The initial default marketplace should use whatever wallet is set as the default wallet currently.
+        // @TODO (zaSmilingIdiot - 2019-07-26):
+        //      Is the wallet creation appropriate here? DefaultMarketService.seedDefaultMarket() is only called from
+        //          ServerStartedListener currently, and only after a check to determine whether the wallet exists and is initialized..
+        //          Makes sense then that this code wouldn't be executed if the wallet is supposed to already exist.
+        //          Unless its correct to start the service against another wallet, and then always create a particular wallet afterwards.
+        //
+        //      Either way, the default wallet on first load should have already been set by the time we get to this point..
+        //          services have already fallen over if its not set. So kindof pointless. Either way, whether this is set, this probably
+        //          needs to be set it to the requested default wallet, not a hard-coded value.
+        //
+        //      I'd imagine the call to walletService.create() would be included in ServerStartedListener.checkConnection() if the wallet is not initialized
+
+        const currentWallet = this.coreRpcService.currentWallet;
+        const defaultMarketWallet: resources.Wallet = await this.walletService.findOneByName(currentWallet)
             .then(value => value.toJSON())
             .catch(async reason => {
                 return await this.walletService.create({
                     profile_id: profile.id,
-                    name: 'market.dat'
+                    name: currentWallet
                 } as WalletCreateRequest).then(value => value.toJSON());
             });
 

--- a/src/api/services/action/BaseActionService.ts
+++ b/src/api/services/action/BaseActionService.ts
@@ -77,17 +77,17 @@ export abstract class BaseActionService implements ActionServiceInterface {
             throw new ValidationException('Invalid MarketplaceMessage.', ['Send failed.']);
         }
 
+        // return smsg fee estimate, if thats what was requested
+        if (params.sendParams.estimateFee) {
+            return await this.smsgService.estimateFee(marketplaceMessage, params.sendParams);
+        }
+
         // if message is paid, make sure we have enough balance to pay for it
         if (params.sendParams.paidMessage) {
             const canAfford = await this.smsgService.canAffordToSendMessage(marketplaceMessage, params.sendParams);
             if (!canAfford) {
                 throw new MessageException('Not enough balance to send the message.');
             }
-        }
-
-        // return smsg fee estimate, if thats what was requested
-        if (params.sendParams.estimateFee) {
-            return await this.smsgService.estimateFee(marketplaceMessage, params.sendParams);
         }
 
         // do whatever still needs to be done before sending the message, extending class should implement


### PR DESCRIPTION
The premise for this change is due to the provision of default variables for wallet setup, but those are somewhat ignored and instead a hard-coded 'market.dat' wallet is created and used (despite checking for wallet setup against an existing wallet).
This is somewhat confusing, so this change sets the default wallet in CoreRpcService to that of the requested default wallet (specified in the env var DEFAULT_WALLET) or otherwise the existing default wallet, and then attempts to register that wallet as the default wallet for the default market.