### PR TITLE
Fixes chain selection process when starting the omplib services.

### DIFF
--- a/src/api/services/OmpService.ts
+++ b/src/api/services/OmpService.ts
@@ -32,19 +32,7 @@ export class OmpService {
         @inject(Types.Core) @named(Core.Logger) public Logger: typeof LoggerType
     ) {
         this.log = new Logger(__filename);
-        this.coreRpcService.getBlockchainInfo().then(
-            (blockInfo: BlockchainInfo) => {
-                const chain = `${blockInfo.chain}net`;
-                const ompConfig = { network: chain} as Config;
-                this.omp = new OpenMarketProtocol(ompConfig);
-                this.omp.inject(Cryptocurrency.PART, coreRpcService);
-            },
-            () => {
-                const ompConfig = { network: 'testnet'} as Config;
-                this.omp = new OpenMarketProtocol(ompConfig);
-                this.omp.inject(Cryptocurrency.PART, coreRpcService);
-            }
-        );
+        this.initializeOmp(coreRpcService);
     }
 
     /**
@@ -122,5 +110,25 @@ export class OmpService {
         );
     }
 
-
+    private initializeOmp(coreRpcService: CoreRpcService): void {
+        coreRpcService.isConnected().then((connected) => {
+            if (!connected) {
+                setTimeout(this.initializeOmp, 500, coreRpcService);
+                return;
+            }
+            coreRpcService.getBlockchainInfo().then(
+                (blockInfo: BlockchainInfo) => {
+                    const chain = `${blockInfo.chain}net`;
+                    const ompConfig = { network: chain} as Config;
+                    this.omp = new OpenMarketProtocol(ompConfig);
+                    this.omp.inject(Cryptocurrency.PART, coreRpcService);
+                },
+                () => {
+                    const ompConfig = { network: 'testnet'} as Config;
+                    this.omp = new OpenMarketProtocol(ompConfig);
+                    this.omp.inject(Cryptocurrency.PART, coreRpcService);
+                }
+            );
+        });
+    }
 }


### PR DESCRIPTION
The existing process falls over when calling coreRpcService.getBlockchainInfo() because coreRpcService is not properly initialized as yet when the request is made (or rather, the connection to particld is not confirmed yet). This results in a network error, forcing the catch statement execution, and consequently forcing the omplib to testnet.
This change attempts to fix this by checking whether rpcCoreService is connected first, and if not, set a timeout to try again (which loops until rpcCoreService.isConnected() returns true. Only then attempt to pick up the current chain and initialize omplib.