### PR TITLE
Fixes express public dir path identification

### DIFF
--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -49,10 +49,10 @@ export class AppConfig implements Configurable {
             }))
 
             // Serve static files like images from the public folder
-            .use(express.static(path.join(__dirname, '../..', 'public'), { maxAge: Infinity }))
+            .use(express.static(path.join(__dirname, '..', 'public'), { maxAge: Infinity }))
 
             // A favicon is a visual cue that client software, like browsers, use to identify a site
-            .use(favicon(path.join(__dirname, '../..', 'public', 'favicon.ico')))
+            .use(favicon(path.join(__dirname, '..', 'public', 'favicon.ico')))
 
             // HTTP request logger middleware for node.js
             .use(morgan('dev', {


### PR DESCRIPTION
__dirname references the dir which contains the script that is currently executing. So the path for the public folder is relative to `app.js` or `module.js` typically. Which means only needing to navigate one path level up to get at the public folder.

Hence, this just reverts the change to the path for the public dir.