### PR TITLE
Fixes expired listing items being deleted incorrectly 

### DIFF
--- a/src/api/models/ListingItem.ts
+++ b/src/api/models/ListingItem.ts
@@ -114,7 +114,10 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
     public static async fetchExpired(): Promise<Collection<ListingItem>> {
         const listingCollection = ListingItem.forge<Model<ListingItem>>()
             .query(qb => {
+                qb.joinRaw(`LEFT JOIN (SELECT listing_item_id, COUNT(*) AS bid_totals FROM bids GROUP BY listing_item_id) bid_totals
+                    ON bid_totals.listing_item_id = listing_items.id`);
                 qb.where('expired_at', '<=', Date.now());
+                qb.andWhereRaw('bid_totals.bid_totals IS NULL');
                 qb.groupBy('listing_items.id');
             });
         return await listingCollection.fetchAll();

--- a/src/api/services/model/ListingItemService.ts
+++ b/src/api/services/model/ListingItemService.ts
@@ -318,6 +318,11 @@ export class ListingItemService {
 
         const listingItem: resources.ListingItem = await this.findOne(id, true).then(value => value.toJSON());
 
+        if (listingItem.Bids.length > 0) {
+            // Prevent listings with associated bids from being removed
+            return;
+        }
+
         // Comments dont have a hard link to ListinItems
         const listingComments = await this.commentService.findAllByTypeAndTarget(CommentType.LISTINGITEM_QUESTION_AND_ANSWERS, listingItem.hash);
         listingComments.forEach((comment) => {


### PR DESCRIPTION
Specifically applies where the listing item was a part of the user's buyflow, ie: a bid was placed/received on the listing item.

Currently,  a ListingItem is selected for removal based on the expiry date, the comments and images for the item are deleted, and then the item itself. Except that if the item is attached to a bid/order, then the attempt to remove the listing item fails with a database error. However, the images and comments for the listing item have since been deleted. This leaves retrieval of this ListingItem information without relevant image information.

This change prevents a listing item from being selected for deletion if the item currently has any associated bids, and thereby attempts to resolve this specific issue (along with that of database errors occurring due to foreign key constraints when attempting the deleting of various records).