### PR TITLE
Removes the optional parameter sent to core sendrawtransaction rpc.

### DIFF
--- a/src/api/services/CoreRpcService.ts
+++ b/src/api/services/CoreRpcService.ts
@@ -628,7 +628,7 @@ export class CoreRpcService extends CtRpc {
     public async sendRawTransaction(hex: string, allowHighFees: boolean = false): Promise<string> {
         const params: any[] = [];
         params.push(hex);
-        params.push(allowHighFees);
+        // params.push(allowHighFees);
         return await this.call('sendrawtransaction', params);
     }
 


### PR DESCRIPTION
- The optional param changes from core 0.18 to 0.19 core versions.